### PR TITLE
Fix \UpCloud\Adapter\GuzzleHttpAdapter to work with GuzzleHttp 6

### DIFF
--- a/src/Adapter/GuzzleHttpAdapter.php
+++ b/src/Adapter/GuzzleHttpAdapter.php
@@ -28,13 +28,17 @@ class GuzzleHttpAdapter implements AdapterInterface
      */
     public function __construct($user, $password, ClientInterface $client = null)
     {
-        $this->client = $client ?: new Client(['defaults' => [
-            'auth' => [
-                $user,
-                $password,
-                'basic'
-            ],
-        ]]);
+	    $options = [
+		    'auth' => [
+			    $user,
+			    $password,
+			    'basic',
+		    ],
+	    ];
+
+	    $this->client = $client ?: new Client(
+		    class_exists(\GuzzleHttp\Psr7\Response::class) ? $options : ['defaults' => $options]
+	    );
     }
 
     /**


### PR DESCRIPTION
The default basic auth credentials must be passed differently to GuzzleHttp\Client() if using GuzzleHttp 6. Current solution works only with GuzzleHttp 5 but this simple class_exists() check fixes it.

Without this fix UpCloud will prompt you for a username and password if you are using GuzzleHttp 6.